### PR TITLE
fix(docs): add autorefs plugin to mkdocs config

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -94,6 +94,8 @@ nav:
 plugins:
   - search
   - mkdocstrings
+  - autorefs:
+      link_titles: true
 
 extra:
   social:


### PR DESCRIPTION
fix(docs): add autorefs plugin to mkdocs config to resolve CI error and ensure compatibility with mkdocstrings