### PR TITLE
feat(parser): improve Spanned wrapper integration in AST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,12 @@ dependencies = [
 [[package]]
 name = "medic_ast"
 version = "0.1.0"
+dependencies = [
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "medic_env"
@@ -509,7 +515,7 @@ dependencies = [
  "medic_lexer",
  "nom",
  "pretty_assertions",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -841,11 +847,31 @@ version = "0.1.0"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/compiler/medic_ast/Cargo.toml
+++ b/compiler/medic_ast/Cargo.toml
@@ -18,6 +18,7 @@ serde = ["dep:serde", "dep:serde_json"]
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 thiserror = "1.0"
+medic_lexer = { path = "../medic_lexer" }
 
 [dev-dependencies]
 pretty_assertions = "1.0"

--- a/compiler/medic_ast/src/conversions.rs
+++ b/compiler/medic_ast/src/conversions.rs
@@ -1,7 +1,22 @@
 use super::ast::{ExpressionNode, StatementNode};
+use super::visit::Span;
+use medic_lexer::token::Location;
 
 impl From<StatementNode> for ExpressionNode {
     fn from(stmt: StatementNode) -> Self {
         ExpressionNode::from_statement(stmt)
+    }
+}
+
+impl From<medic_lexer::Location> for Span {
+    fn from(location: medic_lexer::Location) -> Self {
+        // For a single token, start and end are the same position
+        // The offset in Location is 0-based, and line/column are 1-based, which matches Span
+        Span {
+            start: location.offset,
+            end: location.offset, // Same as start for a single token
+            line: location.line as u32,
+            column: location.column as u32,
+        }
     }
 }

--- a/compiler/medic_parser/src/parser/expressions/mod.rs
+++ b/compiler/medic_parser/src/parser/expressions/mod.rs
@@ -418,12 +418,35 @@ pub fn parse_binary_expression(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>,
                 let (new_input, right) = parse_nested_binary_expression(input, 1, false)?;
                 input = new_input;
 
-                // Create the 'of' expression
-                left = ExpressionNode::Binary(Box::new(BinaryExpressionNode {
+                // Create the 'of' expression with proper span
+                let start_span = match &left {
+                    ExpressionNode::Identifier(i) => i.span,
+                    ExpressionNode::Literal(l) => l.span,
+                    ExpressionNode::Binary(b) => b.span,
+                    _ => Span::default(),
+                };
+                
+                let end_span = match &right {
+                    ExpressionNode::Identifier(i) => i.span,
+                    ExpressionNode::Literal(l) => l.span,
+                    ExpressionNode::Binary(b) => b.span,
+                    _ => Span::default(),
+                };
+                
+                let span = Span {
+                    start: start_span.start,
+                    end: end_span.end,
+                    line: start_span.line,
+                    column: start_span.column,
+                };
+                
+                let bin_expr = BinaryExpressionNode {
                     left,
                     operator: BinaryOperator::Of,
                     right,
-                }));
+                };
+                
+                left = ExpressionNode::Binary(Spanned::new(Box::new(bin_expr), span));
 
                 // Continue parsing any remaining binary expressions
                 let (new_input, expr) = parse_nested_binary_expression(input, 0, false)?;
@@ -431,11 +454,32 @@ pub fn parse_binary_expression(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>,
 
                 // If we parsed more operators, combine with the 'of' expression
                 if let ExpressionNode::Binary(bin) = expr {
-                    left = ExpressionNode::Binary(Box::new(BinaryExpressionNode {
+                    let start_span = match &left {
+                        ExpressionNode::Binary(b) => b.span,
+                        _ => span,
+                    };
+                    
+                    let end_span = match &bin.right {
+                        ExpressionNode::Identifier(i) => i.span,
+                        ExpressionNode::Literal(l) => l.span,
+                        ExpressionNode::Binary(b) => b.span,
+                        _ => span,
+                    };
+                    
+                    let combined_span = Span {
+                        start: start_span.start,
+                        end: end_span.end,
+                        line: start_span.line,
+                        column: start_span.column,
+                    };
+                    
+                    let combined_bin = BinaryExpressionNode {
                         left,
                         operator: bin.operator,
                         right: bin.right,
-                    }));
+                    };
+                    
+                    left = ExpressionNode::Binary(Spanned::new(Box::new(combined_bin), combined_span));
                 }
             }
             TokenType::Per => {
@@ -447,12 +491,35 @@ pub fn parse_binary_expression(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>,
                 let (new_input, right) = parse_nested_binary_expression(input, 1, false)?;
                 input = new_input;
 
-                // Create the 'per' expression
-                left = ExpressionNode::Binary(Box::new(BinaryExpressionNode {
+                // Create the 'per' expression with proper span
+                let start_span = match &left {
+                    ExpressionNode::Identifier(i) => i.span,
+                    ExpressionNode::Literal(l) => l.span,
+                    ExpressionNode::Binary(b) => b.span,
+                    _ => Span::default(),
+                };
+                
+                let end_span = match &right {
+                    ExpressionNode::Identifier(i) => i.span,
+                    ExpressionNode::Literal(l) => l.span,
+                    ExpressionNode::Binary(b) => b.span,
+                    _ => Span::default(),
+                };
+                
+                let span = Span {
+                    start: start_span.start,
+                    end: end_span.end,
+                    line: start_span.line,
+                    column: start_span.column,
+                };
+                
+                let bin_expr = BinaryExpressionNode {
                     left,
                     operator: BinaryOperator::Per,
                     right,
-                }));
+                };
+                
+                left = ExpressionNode::Binary(Spanned::new(Box::new(bin_expr), span));
 
                 // Continue parsing any remaining binary expressions
                 let (new_input, expr) = parse_nested_binary_expression(input, 0, false)?;
@@ -460,11 +527,32 @@ pub fn parse_binary_expression(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>,
 
                 // If we parsed more operators, combine with the 'per' expression
                 if let ExpressionNode::Binary(bin) = expr {
-                    left = ExpressionNode::Binary(Box::new(BinaryExpressionNode {
+                    let start_span = match &left {
+                        ExpressionNode::Binary(b) => b.span,
+                        _ => span,
+                    };
+                    
+                    let end_span = match &bin.right {
+                        ExpressionNode::Identifier(i) => i.span,
+                        ExpressionNode::Literal(l) => l.span,
+                        ExpressionNode::Binary(b) => b.span,
+                        _ => span,
+                    };
+                    
+                    let combined_span = Span {
+                        start: start_span.start,
+                        end: end_span.end,
+                        line: start_span.line,
+                        column: start_span.column,
+                    };
+                    
+                    let combined_bin = BinaryExpressionNode {
                         left,
                         operator: bin.operator,
                         right: bin.right,
-                    }));
+                    };
+                    
+                    left = ExpressionNode::Binary(Spanned::new(Box::new(combined_bin), combined_span));
                 }
             }
             _ => {
@@ -474,11 +562,34 @@ pub fn parse_binary_expression(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>,
 
                 // If we parsed a binary expression, combine it with the left-hand side
                 if let ExpressionNode::Binary(bin) = expr {
-                    left = ExpressionNode::Binary(Box::new(BinaryExpressionNode {
+                    let start_span = match &left {
+                        ExpressionNode::Identifier(i) => i.span,
+                        ExpressionNode::Literal(l) => l.span,
+                        ExpressionNode::Binary(b) => b.span,
+                        _ => Span::default(),
+                    };
+                    
+                    let end_span = match &bin.right {
+                        ExpressionNode::Identifier(i) => i.span,
+                        ExpressionNode::Literal(l) => l.span,
+                        ExpressionNode::Binary(b) => b.span,
+                        _ => start_span,
+                    };
+                    
+                    let combined_span = Span {
+                        start: start_span.start,
+                        end: end_span.end,
+                        line: start_span.line,
+                        column: start_span.column,
+                    };
+                    
+                    let combined_bin = BinaryExpressionNode {
                         left,
                         operator: bin.operator,
                         right: bin.right,
-                    }));
+                    };
+                    
+                    left = ExpressionNode::Binary(Spanned::new(Box::new(combined_bin), combined_span));
                 } else {
                     left = expr;
                 }
@@ -563,21 +674,35 @@ pub fn parse_primary(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, Expressio
                 if let TokenType::Identifier(_) = input.0[0].token_type {
                     let (new_input, right) = parse_identifier(input)?;
                     input = new_input;
-                    return Ok((
-                        input,
-                        ExpressionNode::Binary(Box::new(BinaryExpressionNode {
-                            left: ExpressionNode::Literal(lit),
-                            operator: BinaryOperator::Mul,
-                            right,
-                        })),
-                    ));
+                    // Create a Spanned BinaryExpressionNode
+                    let bin_expr = BinaryExpressionNode {
+                        left: ExpressionNode::Literal(Spanned::new(lit, lit.span)),
+                        operator: BinaryOperator::Mul,
+                        right,
+                    };
+                    
+                    // Create a span that covers the entire binary expression
+                    let span = Span {
+                        start: lit.span.start,
+                        end: match &right {
+                            ExpressionNode::Identifier(i) => i.span.end,
+                            ExpressionNode::Literal(l) => l.span.end,
+                            _ => lit.span.end, // Fallback
+                        },
+                        line: lit.span.line,
+                        column: lit.span.column,
+                    };
+                    
+                    return Ok((input, ExpressionNode::Binary(Spanned::new(Box::new(bin_expr), span))));
                 }
             }
 
             if log::log_enabled!(log::Level::Debug) {
                 log::debug!("Successfully parsed number literal: {:?}", lit);
             }
-            Ok((input, ExpressionNode::Literal(lit)))
+            // Wrap the literal in a Spanned
+            let span = lit.span;
+            Ok((input, ExpressionNode::Literal(Spanned::new(lit, span))))
         }
         TokenType::String(_) | TokenType::Boolean(_) => {
             if log::log_enabled!(log::Level::Debug) {
@@ -593,7 +718,9 @@ pub fn parse_primary(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, Expressio
             if log::log_enabled!(log::Level::Debug) {
                 log::debug!("Successfully parsed literal: {:?}", lit);
             }
-            Ok((input, ExpressionNode::Literal(lit)))
+            // Wrap the literal in a Spanned
+            let span = lit.span;
+            Ok((input, ExpressionNode::Literal(Spanned::new(lit, span))))
         }
         // Match expressions are handled in the first pattern match above
         // Handle identifiers, member expressions, and implicit multiplication

--- a/compiler/medic_parser/src/parser/identifiers/mod.rs
+++ b/compiler/medic_parser/src/parser/identifiers/mod.rs
@@ -4,6 +4,7 @@ use nom::IResult;
 use crate::parser::{
     take_token_if, ExpressionNode, IdentifierNode, MemberExpressionNode, TokenSlice, TokenType,
 };
+use medic_ast::ast::{Spanned, Span};
 
 use super::expressions::parse_expression;
 
@@ -60,132 +61,125 @@ pub fn parse_identifier(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, Expres
                 };
                 log::debug!("Successfully parsed identifier: {}", name);
 
+                // Create a Spanned identifier node
+                let ident_node = IdentifierNode::new(name.to_string());
+                let span: Span = token.location.into();
+                let expr = ExpressionNode::Identifier(Spanned::new(ident_node, span));
+
                 // Check for member access
                 if let Some(next_token) = input.peek() {
                     if matches!(next_token.token_type, TokenType::Dot) {
-                        return parse_member_expression(
-                            input,
-                            ExpressionNode::Identifier(IdentifierNode {
-                                name: name.to_string(),
-                            }),
-                        );
+                        return parse_member_expression(input, expr);
                     }
                 }
 
-                Ok((
-                    input,
-                    ExpressionNode::Identifier(IdentifierNode {
-                        name: name.to_string(),
-                    }),
-                ))
+                Ok((input, expr))
             }
             // Handle healthcare keywords as identifiers
             TokenType::Patient => {
                 let (input, _) =
                     take_token_if(|t| matches!(t, TokenType::Patient), ErrorKind::Tag)(input)?;
 
+                // Create a Spanned identifier node for 'patient' keyword
+                let ident_node = IdentifierNode::new("patient".to_string());
+                let span: Span = token.location.into();
+                let expr = ExpressionNode::Identifier(Spanned::new(ident_node, span));
+
                 // Check for member access
                 if let Some(next_token) = input.peek() {
                     if matches!(next_token.token_type, TokenType::Dot) {
-                        return parse_member_expression(
-                            input,
-                            ExpressionNode::Identifier(IdentifierNode {
-                                name: "patient".to_string(),
-                            }),
-                        );
+                        return parse_member_expression(input, expr);
                     }
                 }
 
-                Ok((
-                    input,
-                    ExpressionNode::Identifier(IdentifierNode {
-                        name: "patient".to_string(),
-                    }),
-                ))
+                Ok((input, expr))
             }
+            // Handle other keywords that can be used as identifiers
             TokenType::Observation => {
                 let (input, _) =
                     take_token_if(|t| matches!(t, TokenType::Observation), ErrorKind::Tag)(input)?;
 
+                // Create a Spanned identifier node for 'observation' keyword
+                let ident_node = IdentifierNode::new("observation".to_string());
+                let span: Span = token.location.into();
+                let expr = ExpressionNode::Identifier(Spanned::new(ident_node, span));
+
                 // Check for member access
                 if let Some(next_token) = input.peek() {
                     if matches!(next_token.token_type, TokenType::Dot) {
-                        return parse_member_expression(
-                            input,
-                            ExpressionNode::Identifier(IdentifierNode {
-                                name: "observation".to_string(),
-                            }),
-                        );
+                        return parse_member_expression(input, expr);
                     }
                 }
 
-                Ok((
-                    input,
-                    ExpressionNode::Identifier(IdentifierNode {
-                        name: "observation".to_string(),
-                    }),
-                ))
+                Ok((input, expr))
             }
             TokenType::Medication => {
                 let (input, _) =
                     take_token_if(|t| matches!(t, TokenType::Medication), ErrorKind::Tag)(input)?;
 
-                // Check for member access
-                if let Some(next_token) = input.peek() {
-                    if matches!(next_token.token_type, TokenType::Dot) {
-                        return parse_member_expression(
-                            input,
-                            ExpressionNode::Identifier(IdentifierNode {
-                                name: "medication".to_string(),
-                            }),
-                        );
-                    }
-                }
-
-                Ok((
-                    input,
-                    ExpressionNode::Identifier(IdentifierNode {
-                        name: "medication".to_string(),
-                    }),
-                ))
-            }
-            // Handle other keywords that can be used as identifiers
-            TokenType::If | TokenType::Else => {
-                let name = match token.token_type {
-                    TokenType::If => "if",
-                    TokenType::Else => "else",
-                    _ => unreachable!(),
-                };
-                let (input, _) = take_token_if(|t| t == &token.token_type, ErrorKind::Tag)(input)?;
+                // Create a Spanned identifier node for 'medication' keyword
+                let ident_node = IdentifierNode::new("medication".to_string());
+                let span: Span = token.location.into();
+                let expr = ExpressionNode::Identifier(Spanned::new(ident_node, span));
 
                 // Check for member access
                 if let Some(next_token) = input.peek() {
                     if matches!(next_token.token_type, TokenType::Dot) {
-                        return parse_member_expression(
-                            input,
-                            ExpressionNode::Identifier(IdentifierNode {
-                                name: name.to_string(),
-                            }),
-                        );
+                        return parse_member_expression(input, expr);
                     }
                 }
 
-                Ok((
-                    input,
-                    ExpressionNode::Identifier(IdentifierNode {
-                        name: name.to_string(),
-                    }),
-                ))
+                Ok((input, expr))
             }
-            _ => Err(nom::Err::Error(nom::error::Error::new(
-                input,
-                ErrorKind::Tag,
-            ))),
+            TokenType::If => {
+                let (input, _) = take_token_if(|t| matches!(t, TokenType::If), ErrorKind::Tag)(input)?;
+
+                // Create a Spanned identifier node for 'if' keyword
+                let ident_node = IdentifierNode::new("if".to_string());
+                let span: Span = token.location.into();
+                let expr = ExpressionNode::Identifier(Spanned::new(ident_node, span));
+
+                // Check for member access
+                if let Some(next_token) = input.peek() {
+                    if matches!(next_token.token_type, TokenType::Dot) {
+                        return parse_member_expression(input, expr);
+                    }
+                }
+
+                Ok((input, expr))
+            }
+            TokenType::Else => {
+                let (input, _) =
+                    take_token_if(|t| matches!(t, TokenType::Else), ErrorKind::Tag)(input)?;
+
+                // Create a Spanned identifier node for 'else' keyword
+                let ident_node = IdentifierNode::new("else".to_string());
+                let span: Span = token.location.into();
+                let expr = ExpressionNode::Identifier(Spanned::new(ident_node, span));
+
+                // Check for member access
+                if let Some(next_token) = input.peek() {
+                    if matches!(next_token.token_type, TokenType::Dot) {
+                        return parse_member_expression(input, expr);
+                    }
+                }
+
+                Ok((input, expr))
+            }
+            // Add other keyword cases as needed
+            _ => {
+                log::error!("Expected identifier, found: {:?}", token.token_type);
+                Err(nom::Err::Error(nom::error::Error::new(
+                    input,
+                    ErrorKind::Tag,
+                )))
+            }
         }
     } else {
+        log::error!("Unexpected end of input in parse_identifier");
         Err(nom::Err::Error(nom::error::Error::new(
             input,
-            ErrorKind::Tag,
+            ErrorKind::Eof,
         )))
     }
 }
@@ -217,73 +211,81 @@ pub fn parse_identifier(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, Expres
 /// assert!(matches!(expr, ExpressionNode::Member { .. }));
 /// ```
 pub fn parse_member_expression(
-    input: TokenSlice<'_>,
-    object: ExpressionNode,
+    mut input: TokenSlice<'_>,
+    mut object: ExpressionNode,
 ) -> IResult<TokenSlice<'_>, ExpressionNode> {
-    let mut input = input;
-    let mut expr = object;
+    log::debug!("=== parse_member_expression ===");
+    log::debug!("Initial object: {:?}", object);
 
-    // Keep parsing member accesses as long as we find dots
+    // Continue processing as long as we have a dot followed by an identifier
     while let Some(token) = input.peek() {
         if !matches!(token.token_type, TokenType::Dot) {
             break;
         }
 
         // Consume the dot
-        input = input.advance();
+        let (new_input, _) = take_token_if(|t| matches!(t, TokenType::Dot), ErrorKind::Tag)(input)?;
+        input = new_input;
 
-        // Parse the next identifier or keyword after the dot
-        let (new_input, ident_name) = if let Ok((input, token)) =
-            take_token_if(|t| matches!(t, TokenType::Identifier(_)), ErrorKind::Tag)(input)
-        {
-            // Handle regular identifiers
-            if let TokenType::Identifier(name) = &token.token_type {
-                (input, name.to_string())
-            } else {
+        // Parse the property name (must be an identifier)
+        let (new_input, property) = match input.peek() {
+            Some(t) if matches!(t.token_type, TokenType::Identifier(_)) => {
+                let (input, _) = take_token_if(
+                    |t| matches!(t, TokenType::Identifier(_)),
+                    ErrorKind::Tag,
+                )(input)?;
+                
+                // Get the token we just consumed to create a proper Spanned identifier
+                let token = input.0[input.0.len() - 1];
+                let name = match &token.token_type {
+                    TokenType::Identifier(name) => name.to_string(),
+                    _ => unreachable!(),
+                };
+                
+                // Create a Spanned identifier node for the property
+                let ident_node = IdentifierNode::new(name);
+                let spanned_ident = Spanned::new(ident_node, token.location.into());
+                
+                (input, spanned_ident)
+            }
+            _ => {
+                log::error!("Expected identifier after dot in member expression");
                 return Err(nom::Err::Error(nom::error::Error::new(
                     input,
                     ErrorKind::Tag,
                 )));
             }
-        } else if let Ok((input, token)) = take_token_if(
-            |t| {
-                matches!(
-                    t,
-                    TokenType::Patient
-                        | TokenType::Observation
-                        | TokenType::Medication
-                        | TokenType::If
-                        | TokenType::Else
-                )
-            },
-            ErrorKind::Tag,
-        )(input)
-        {
-            // Handle keywords that can be used as identifiers
-            let name = match token.token_type {
-                TokenType::Patient => "patient",
-                TokenType::Observation => "observation",
-                TokenType::Medication => "medication",
-                TokenType::If => "if",
-                TokenType::Else => "else",
-                _ => unreachable!(),
-            };
-            (input, name.to_string())
-        } else {
-            return Err(nom::Err::Error(nom::error::Error::new(
-                input,
-                ErrorKind::Tag,
-            )));
         };
-
-        // Create a new member expression with the current identifier
-        expr = ExpressionNode::Member(Box::new(MemberExpressionNode {
-            object: expr,
-            property: IdentifierNode { name: ident_name },
-        }));
-
         input = new_input;
+
+        // Get the span from the start of the object to the end of the property
+        let start_span = match &object {
+            ExpressionNode::Identifier(i) => i.span,
+            ExpressionNode::Member(m) => m.span,
+            _ => unreachable!("Member expression can only have identifier or member as object"),
+        };
+        
+        // Create a new member expression node with the current object and property
+        let member_expr = MemberExpressionNode {
+            object: Box::new(object),
+            property: property.node, // Extract the IdentifierNode from Spanned
+        };
+        
+        // Create a span that covers the entire member expression
+        let span = Span {
+            start: start_span.start,
+            end: property.span.end,
+            line: start_span.line,
+            column: start_span.column,
+        };
+        
+        // Wrap the member expression in a Spanned and then in an ExpressionNode::Member
+        let member_expr = ExpressionNode::Member(Spanned::new(Box::new(member_expr), span));
+        
+        // Update the object for the next iteration
+        object = member_expr;
+        log::debug!("Updated object: {:?}", object);
     }
 
-    Ok((input, expr))
+    Ok((input, object))
 }

--- a/compiler/medic_parser/src/parser/statements/mod.rs
+++ b/compiler/medic_parser/src/parser/statements/mod.rs
@@ -146,11 +146,15 @@ pub fn parse_let_statement(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, Sta
     // Extract the identifier from the expression
     log::debug!("Extracting identifier from expression");
     let ident = if let ExpressionNode::Identifier(ident) = ident_expr {
-        log::debug!("Extracted identifier: {}", ident.name);
-        // Create a new IdentifierNode with the same name
-        IdentifierNode {
-            name: ident.name.clone(),
-        }
+        log::debug!("Extracted identifier: {}", ident.node.name);
+        // Create a new IdentifierNode with the same name and span
+        let span = ident.span;
+        Spanned::new(
+            IdentifierNode {
+                name: ident.node.name.clone(),
+            },
+            span,
+        )
     } else {
         log::error!(
             "Expected identifier after 'let', got {:?} at {}:{}",
@@ -245,12 +249,27 @@ pub fn parse_let_statement(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, Sta
         input
     };
 
-    let let_stmt = LetStatementNode {
-        name: ident,
+    // Create the let statement with proper span
+    let span = Span {
+        start: ident.span.start,
+        end: match &expr {
+            ExpressionNode::Identifier(i) => i.span.end,
+            ExpressionNode::Literal(l) => l.span.end,
+            ExpressionNode::Binary(b) => b.span.end,
+            _ => ident.span.end, // Fallback
+        },
+        line: ident.span.line,
+        column: ident.span.column,
+    };
+    
+    let stmt = LetStatementNode {
+        name: ident.node,
         value: expr,
     };
+    
+    let stmt = Spanned::new(stmt, span);
 
-    Ok((input, StatementNode::Let(Box::new(let_stmt))))
+    Ok((input, StatementNode::Let(Box::new(stmt))))
 }
 
 // ReturnNode is already imported above
@@ -292,24 +311,53 @@ pub fn parse_let_statement(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, Sta
 /// # Returns
 /// A tuple containing the remaining input and the parsed return statement if successful
 pub fn parse_return_statement(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, StatementNode> {
-    // Consume 'return' keyword
-    let (mut input, _) = take_token_if(|t| matches!(t, TokenType::Return), ErrorKind::Tag)(input)?;
-
+    // Consume 'return' keyword and get its span
+    let (mut input, return_token) = take_token_if(|t| matches!(t, TokenType::Return), ErrorKind::Tag)(input)?;
+    let start_span = return_token.location.into();
+    
     // Check if there's an expression to parse
     if let Ok((new_input, expr)) = parse_expression(input) {
         input = new_input;
-        let (new_input, _) =
-            take_token_if(|t| matches!(t, TokenType::Semicolon), ErrorKind::Tag)(input)?;
+        let (new_input, semicolon_token) = take_token_if(
+            |t| matches!(t, TokenType::Semicolon), 
+            ErrorKind::Tag
+        )(input)?;
+        
+        // Create a span from the return keyword to the semicolon
+        let end_span = semicolon_token.location.into();
+        let span = Span {
+            start: start_span.start,
+            end: end_span.end,
+            line: start_span.line,
+            column: start_span.column,
+        };
+        
         let return_node = ReturnNode {
             value: Some(Box::new(expr)),
         };
-        Ok((new_input, StatementNode::Return(Box::new(return_node))))
+        
+        Ok((new_input, StatementNode::Return(Spanned::new(Box::new(return_node), span))))
     } else {
         // No expression, just a bare return
-        let (new_input, _) =
-            take_token_if(|t| matches!(t, TokenType::Semicolon), ErrorKind::Tag)(input)?;
-        let return_node = ReturnNode { value: None };
-        Ok((new_input, StatementNode::Return(Box::new(return_node))))
+        let (new_input, semicolon_token) = take_token_if(
+            |t| matches!(t, TokenType::Semicolon), 
+            ErrorKind::Tag
+        )(input)?;
+        
+        // Create a span from the return keyword to the semicolon
+        let end_span = semicolon_token.location.into();
+        let span = Span {
+            start: start_span.start,
+            end: end_span.end,
+            line: start_span.line,
+            column: start_span.column,
+        };
+        
+        let return_node = ReturnNode { 
+            value: None 
+        };
+        
+        Ok((new_input, StatementNode::Return(Spanned::new(Box::new(return_node), span))))
     }
 }
 
@@ -341,9 +389,10 @@ pub fn parse_return_statement(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, 
 /// # Returns
 /// A tuple containing the remaining input and the parsed if statement if successful
 pub fn parse_if_statement(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, StatementNode> {
-    // Consume 'if' keyword
-    let (mut input, _) = take_token_if(|t| matches!(t, TokenType::If), ErrorKind::Tag)(input)?;
-
+    // Consume 'if' keyword and get its span
+    let (mut input, if_token) = take_token_if(|t| matches!(t, TokenType::If), ErrorKind::Tag)(input)?;
+    let start_span = if_token.location.into();
+    
     // Parse the condition as a full expression
     let (new_input, condition) = parse_expression(input)?;
     input = new_input;
@@ -351,44 +400,53 @@ pub fn parse_if_statement(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, Stat
     // Parse the then block
     let (new_input, then_block) = parse_block(input)?;
     input = new_input;
+    
+    // Track the end span for the if statement
+    let mut end_span = then_block.span;
+    let mut else_branch = None;
 
     // Check for else clause
-    if let Ok((new_input, _)) =
+    if let Ok((new_input, else_token)) =
         take_token_if(|t| matches!(t, TokenType::Else), ErrorKind::Tag)(input)
     {
+        input = new_input;
+        
         // Parse else if or else block
         if let Ok((new_input, _)) =
-            take_token_if(|t| matches!(t, TokenType::If), ErrorKind::Tag)(new_input)
+            take_token_if(|t| matches!(t, TokenType::If), ErrorKind::Tag)(input)
         {
             // It's an else if
             let (new_input, else_if) = parse_if_statement(new_input)?;
-            let if_node = IfNode {
-                condition,
-                then_branch: then_block,
-                else_branch: Some(BlockNode {
-                    statements: vec![else_if],
-                }),
-            };
-            Ok((new_input, StatementNode::If(Box::new(if_node))))
+            end_span = else_if.span();
+            else_branch = Some(BlockNode {
+                statements: vec![else_if],
+                span: end_span,
+            });
+            input = new_input;
         } else {
             // It's an else block
-            let (new_input, else_block) = parse_block(new_input)?;
-            let if_node = IfNode {
-                condition,
-                then_branch: then_block,
-                else_branch: Some(else_block),
-            };
-            Ok((new_input, StatementNode::If(Box::new(if_node))))
+            let (new_input, else_block) = parse_block(input)?;
+            end_span = else_block.span;
+            else_branch = Some(else_block);
+            input = new_input;
         }
-    } else {
-        // No else clause
-        let if_node = IfNode {
-            condition,
-            then_branch: then_block,
-            else_branch: None,
-        };
-        Ok((input, StatementNode::If(Box::new(if_node))))
     }
+    
+    // Create the full span from 'if' to the end of the else block (or then block if no else)
+    let span = Span {
+        start: start_span.start,
+        end: end_span.end,
+        line: start_span.line,
+        column: start_span.column,
+    };
+    
+    let if_node = IfNode {
+        condition,
+        then_branch: then_block,
+        else_branch: else_branch,
+    };
+    
+    Ok((input, StatementNode::If(Spanned::new(Box::new(if_node), span))))
 }
 
 // WhileNode is already imported above
@@ -431,8 +489,9 @@ pub fn parse_if_statement(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, Stat
 pub fn parse_while_statement(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, StatementNode> {
     log::trace!("Starting to parse while statement");
 
-    // Consume 'while' keyword
-    let (input, _) = take_token_if(|t| matches!(t, TokenType::While), ErrorKind::Tag)(input)?;
+    // Consume 'while' keyword and get its span
+    let (input, while_token) = take_token_if(|t| matches!(t, TokenType::While), ErrorKind::Tag)(input)?;
+    let start_span = while_token.location.into();
 
     log::trace!("After consuming 'while' keyword");
 
@@ -455,7 +514,6 @@ pub fn parse_while_statement(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, S
     };
 
     log::debug!("Successfully parsed while condition");
-
     log::debug!("Condition parsed successfully: {:?}", condition);
 
     // Parse the body block
@@ -466,9 +524,21 @@ pub fn parse_while_statement(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, S
     })?;
 
     log::trace!("Body block parsed successfully");
+    
+    // Create the full span from 'while' to the end of the body block
+    let span = Span {
+        start: start_span.start,
+        end: body.span.end,
+        line: start_span.line,
+        column: start_span.column,
+    };
 
-    let while_node = WhileNode { condition, body };
-    Ok((input, StatementNode::While(Box::new(while_node))))
+    let while_node = WhileNode { 
+        condition,
+        body,
+    };
+    
+    Ok((input, StatementNode::While(Spanned::new(Box::new(while_node), span))))
 }
 
 /// Parses an assignment statement (e.g., `x = 42;` or `x.y = z + 1;`).
@@ -481,36 +551,57 @@ pub fn parse_while_statement(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, S
 pub fn parse_assignment_statement(input: TokenSlice<'_>) -> IResult<TokenSlice<'_>, StatementNode> {
     // Parse the target (l-value). We only want an identifier or member access,
     // not the whole `= …` expression.
-    //
     // `parse_identifier` already understands dotted member chains, so it is
     // sufficient here and guarantees we stop *before* the `=`.
     let (input, target) = parse_identifier(input)?;
+    let start_span = match &target {
+        ExpressionNode::Identifier(ident) => ident.span,
+        ExpressionNode::Member(member) => member.span,
+        _ => return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            ErrorKind::Tag,
+        ))),
+    };
 
-    // Check if the next token is an equals sign
-    let (input, _) = take_token_if(|t| matches!(t, TokenType::Equal), ErrorKind::Tag)(input)?;
+    // Get the equals sign token for span calculation
+    let (input, equals_token) = take_token_if(|t| matches!(t, TokenType::Equal), ErrorKind::Tag)(input)?;
+    let eq_span = equals_token.location.into();
 
     // Parse the expression after the equals sign
     let input = input.skip_whitespace();
     let (input, value) = parse_expression(input)?;
-
-    // Convert the target to an ExpressionNode::Identifier
-    let target_expr = match target {
-        ExpressionNode::Identifier(ident) => ident,
-        _ => {
-            return Err(nom::Err::Error(nom::error::Error::new(
-                input,
-                ErrorKind::Tag,
-            )))
-        }
+    
+    // Calculate the full span from target start to value end
+    let end_span = match &value {
+        ExpressionNode::Identifier(ident) => ident.span,
+        ExpressionNode::Literal(lit) => lit.span,
+        ExpressionNode::Binary(bin) => bin.span,
+        ExpressionNode::Member(mem) => mem.span,
+        _ => start_span, // Fallback
+    };
+    
+    let span = Span {
+        start: start_span.start,
+        end: end_span.end,
+        line: start_span.line,
+        column: start_span.column,
     };
 
-    // Create and return the assignment node
-    let assignment = StatementNode::Assignment(Box::new(AssignmentNode {
-        target: ExpressionNode::Identifier(target_expr),
+    // Create the assignment node with proper spans
+    let assignment = AssignmentNode {
+        target: match target {
+            ExpressionNode::Identifier(ident) => ExpressionNode::Identifier(ident),
+            ExpressionNode::Member(member) => ExpressionNode::Member(member),
+            _ => return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                ErrorKind::Tag,
+            ))),
+        },
         value,
-    }));
-
-    Ok((input, assignment))
+    };
+    
+    // Wrap in Spanned and return
+    Ok((input, StatementNode::Assignment(Spanned::new(Box::new(assignment), span))))
 }
 /// where <arms> is a comma-separated list of patterns and expressions.
 ///

--- a/compiler/medic_parser/src/parser/statements/tests/mod.rs
+++ b/compiler/medic_parser/src/parser/statements/tests/mod.rs
@@ -148,14 +148,15 @@ mod statements_test {
 
         // Verify AST structure for binary expression match
         if let Ok((_, StatementNode::Match(match_stmt))) = result {
-            if let ExpressionNode::Binary(bin_expr) = match_stmt.expr.as_ref() {
-                if let ExpressionNode::Identifier(ident) = &bin_expr.left {
-                    assert_eq!(ident.name, "x");
+            if let ExpressionNode::Binary(bin_expr) = &match_stmt.expr.node {
+                if let ExpressionNode::Identifier(ident) = &bin_expr.node.left.node {
+                    assert_eq!(ident.node.name, "x");
                 } else {
                     panic!("Expected 'x' as left operand of binary expression");
                 }
-                assert_eq!(bin_expr.operator.to_string(), "+");
-                if let ExpressionNode::Literal(LiteralNode::Int(1)) = &bin_expr.right {
+                assert_eq!(bin_expr.node.operator.to_string(), "+");
+                if let ExpressionNode::Literal(lit) = &bin_expr.node.right.node {
+                    if let LiteralNode::Int(1) = lit.node {
                     // Correct
                 } else {
                     panic!("Expected 1 as right operand of binary expression");
@@ -181,14 +182,14 @@ mod statements_test {
 
         // Verify AST structure for function call match
         if let Ok((_, StatementNode::Match(match_stmt))) = result {
-            if let ExpressionNode::Call(call_expr) = match_stmt.expr.as_ref() {
-                if let ExpressionNode::Identifier(ident) = &call_expr.callee {
-                    assert_eq!(ident.name, "some_function");
+            if let ExpressionNode::Call(call_expr) = &match_stmt.expr.node {
+                if let ExpressionNode::Identifier(ident) = &call_expr.node.callee.node {
+                    assert_eq!(ident.node.name, "some_function");
                 } else {
                     panic!("Expected 'some_function' as callee");
                 }
                 assert!(
-                    call_expr.arguments.is_empty(),
+                    call_expr.node.arguments.is_empty(),
                     "Expected no arguments in function call"
                 );
             } else {
@@ -212,13 +213,13 @@ mod statements_test {
 
         // Verify AST structure for member expression match
         if let Ok((_, StatementNode::Match(match_stmt))) = result {
-            if let ExpressionNode::Member(member_expr) = match_stmt.expr.as_ref() {
-                if let ExpressionNode::Identifier(ident) = &member_expr.object {
-                    assert_eq!(ident.name, "some_object");
+            if let ExpressionNode::Member(member_expr) = &match_stmt.expr.node {
+                if let ExpressionNode::Identifier(ident) = &member_expr.node.object.node {
+                    assert_eq!(ident.node.name, "some_object");
                 } else {
                     panic!("Expected 'some_object' as object in member expression");
                 }
-                assert_eq!(member_expr.property.name, "property");
+                assert_eq!(member_expr.node.property.node.name, "property");
             } else {
                 panic!(
                     "Expected member expression as match expression, got {:?}",


### PR DESCRIPTION
- Add span field to BlockNode for better source location tracking
- Update parse_block to capture and set proper spans for blocks
- Enhance parse_member_expression with correct span handling
- Improve ExpressionNode::from_statement to maintain span information
- Ensure consistent Spanned wrapping throughout the parser